### PR TITLE
Add support for AMD modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = function(options) {
   var projectName = getPackageName(projectPath);
   var srcPath = path.join(projectPath, 'src');
 
-  var targets = options.targets || ['js', 'cjs', 'umd'];
+  var targets = options.targets || ['js', 'cjs', 'umd', 'amd'];
 
   assert.ok(targets instanceof Array, 'targets option must be an array of target formats');
   normalizeTargets(targets);
@@ -102,6 +102,22 @@ module.exports = function(options) {
     umd = stew.mv(umd, 'umd');
 
     outputTrees.push(umd);
+  }
+
+  if (hasTarget('amd')) {
+    var amd = rollup(js, {
+      inputFiles: ['**/*.js'],
+      rollup: {
+        format: 'amd',
+        moduleId: options.moduleName || projectName,
+        entry: options.entry || 'index.js',
+        dest: projectName + '.js'
+      }
+    });
+
+    amd = stew.mv(amd, 'amd');
+
+    outputTrees.push(amd);
   }
 
   return mergeTrees(outputTrees);

--- a/test/helpers/load-global.js
+++ b/test/helpers/load-global.js
@@ -1,10 +1,10 @@
 var vm = require('vm');
 var fs = require('fs');
 
-module.exports = function(filePath) {
+module.exports = function(filePath, sandbox) {
   var code = fs.readFileSync(filePath);
 
-  var sandbox = {};
+  sandbox = sandbox || {};
   vm.runInNewContext(code, sandbox);
 
   return sandbox;

--- a/test/javascript-build-test.js
+++ b/test/javascript-build-test.js
@@ -81,6 +81,24 @@ describe('JavaScript projects', function() {
     expect(simpleApp.foo()).to.equal('foo');
     expect(simpleApp.bar()).to.equal('bar');
   });
+
+  it('produces an AMD build', function() {
+    exists(dist('amd'));
+
+    var modules = {};
+    loadGlobal(dist('amd/simple-app.js'), {
+      define: function (name, dependencies, body) {
+        modules[name] = body;
+      }
+    });
+
+    var simpleApp = {};
+    modules['simple-app'](simpleApp);
+
+    expect(simpleApp.default()).to.equal('default');
+    expect(simpleApp.foo()).to.equal('foo');
+    expect(simpleApp.bar()).to.equal('bar');
+  });
 });
 
 function buildPackage(packagePath) {


### PR DESCRIPTION
This adds support for AMD modules using the `amd` flag in the targets section (or by default).

I'm not sure if the custom name needs to be dasherized in this case, but I'm making the assumption that it should be left alone for `amd` compilation.